### PR TITLE
fix: fetch implementation to minibus client

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -34,7 +34,9 @@ export default {
 
     const minibus = new Minibus({
       endpoint: env.MINIBUS_API_URL,
-      headers: { Authorization: `Basic ${env.MINIBUS_BASIC_AUTH}` }
+      headers: { Authorization: `Basic ${env.MINIBUS_BASIC_AUTH}` },
+      // @ts-ignore needs fetch from worker scope. globalThis fetch errors with TypeError: Illegal invocation
+      fetch: (...args) => fetch(...args)
     })
     const miniswap = new Miniswap(minibus)
 


### PR DESCRIPTION
Not sure on the root reason for this. But if we rely on https://github.com/web3-storage/minibus-client/blob/main/index.js#L13 globalthis.fetch we get error `TypeError: Illegal invocation` . Would be good to know what are the differences, but will leave that outside the scope of this PR